### PR TITLE
Make `--auth_submitfield` optional

### DIFF
--- a/zap-baseline-custom.py
+++ b/zap-baseline-custom.py
@@ -505,8 +505,7 @@ def main(argv):
                 passwordField.clear()
                 passwordField.send_keys(auth_password)
 
-            if auth_submit_field_name:
-                find_element(auth_submit_field_name, "//input[@type='submit']").click()
+            find_element(auth_submit_field_name, "//input[@type='submit']").click()
 
         # Wait for all requests to finish - not needed?
         time.sleep(30)


### PR DESCRIPTION
If `--auth_submitfield` is not provided, the form is not submitted, and the authentication will not succeed

(unless I'm missing something obvious?)