### PR TITLE
Some small docker / Podman related improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.github/
+.gitignore
+README.md
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Check podman version
+        run: podman --version 
+      - name: Cache Container images
+        uses: actions/cache@v2
+        with:
+          path: ~/.local/share/containers/storage
+          key: ${{ runner.os }}-cache-v1-${{ hashFiles('Dockerfile') }}
+          restore-keys: ${{ runner.os }}-restore
+      - name: Build container
+        run: podman build -t ictu/zap2docker-weekly . 
+      - name: change accessibility for cache
+        run: podman unshare chmod -R 755 ~/.local/share/containers/storage/
+        

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ LABEL maintainer="Dick Snel <dick.snel@ictu.nl>"
 USER root
 
 RUN mkdir /zap/wrk \
-    && mkdir -p /home/zap/.cache/pip \
 	&& cd /opt \
 	&& wget -qO- -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.29.0/geckodriver-v0.29.0-linux64.tar.gz \
 	&& tar -xvzf geckodriver.tar.gz \
@@ -14,9 +13,7 @@ RUN mkdir /zap/wrk \
 	&& ln -s /opt/geckodriver /usr/bin/geckodriver \
 	&& export PATH=$PATH:/usr/bin/geckodriver
 
-ADD *.py /zap/
-ADD requirements.txt /zap/
-ADD scripts/* /zap/scripts/
+ADD . /zap/
 
 ADD scripts /home/zap/.ZAP_D/scripts/scripts/active/
 RUN chmod 777 /home/zap/.ZAP_D/scripts/scripts/active/
@@ -24,12 +21,6 @@ RUN chmod 777 /home/zap/.ZAP_D/scripts/scripts/active/
 RUN pip install -r /zap/requirements.txt \
 	&& chown -R zap:zap /zap/ \
 	&& chmod +x /zap/zap-baseline-custom.py
-
-RUN chgrp -R 0 /zap
-RUN chmod -R g=u /zap 
-RUN chown -R zap:zap /home/zap/.cache
-RUN chgrp -R 0 /home/zap
-RUN chmod -R g=u /home/zap
 
 USER zap
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,17 @@ LABEL maintainer="Dick Snel <dick.snel@ictu.nl>"
 USER root
 
 RUN mkdir /zap/wrk \
+    && mkdir -p /home/zap/.cache/pip \
 	&& cd /opt \
-	&& wget -qO- -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz \
+	&& wget -qO- -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.29.0/geckodriver-v0.29.0-linux64.tar.gz \
 	&& tar -xvzf geckodriver.tar.gz \
 	&& chmod +x geckodriver \
 	&& ln -s /opt/geckodriver /usr/bin/geckodriver \
 	&& export PATH=$PATH:/usr/bin/geckodriver
 
-ADD . /zap/
+ADD *.py /zap/
+ADD requirements.txt /zap/
+ADD scripts/* /zap/scripts/
 
 ADD scripts /home/zap/.ZAP_D/scripts/scripts/active/
 RUN chmod 777 /home/zap/.ZAP_D/scripts/scripts/active/
@@ -21,6 +24,12 @@ RUN chmod 777 /home/zap/.ZAP_D/scripts/scripts/active/
 RUN pip install -r /zap/requirements.txt \
 	&& chown -R zap:zap /zap/ \
 	&& chmod +x /zap/zap-baseline-custom.py
+
+RUN chgrp -R 0 /zap
+RUN chmod -R g=u /zap 
+RUN chown -R zap:zap /home/zap/.cache
+RUN chgrp -R 0 /home/zap
+RUN chmod -R g=u /home/zap
 
 USER zap
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyVirtualDisplay==1.3.2
+PyVirtualDisplay==2.1
 selenium==3.141.0


### PR DESCRIPTION
By adding .dockerignore docker builds will not send all files to the docker daemon and will ignore the specified files in the docker add step. The latest podman version will also use this file. For older versions a more defined ADD step is an alternative.
The pip install requires an accessible cache dir.
Update of Gecko driver
Update of PyVirtualDisplay
Redhat recommended chrgrp/chmod added for running rootless containers.
Github Action workflow added. This does a podman build in the pipeline to see if the build succeeds. Can be extended later on with some additional test or pushing the image to docker hub e.g. 